### PR TITLE
Fix missing returns, inconsistent URLs, comparison operators, and getSiteCommand

### DIFF
--- a/src/Actions/ManagesCertificates.php
+++ b/src/Actions/ManagesCertificates.php
@@ -94,7 +94,7 @@ trait ManagesCertificates
      * @param  int  $siteId
      * @param  int  $certificateId
      * @param  bool  $wait
-     * @return void
+     * @return \Laravel\Forge\Resources\Certificate
      */
     public function installCertificate($serverId, $siteId, $certificateId, array $data, $wait = true)
     {
@@ -107,6 +107,8 @@ trait ManagesCertificates
                 return $certificate->status == 'installed';
             });
         }
+
+        return $this->certificate($serverId, $siteId, $certificateId);
     }
 
     /**
@@ -116,7 +118,7 @@ trait ManagesCertificates
      * @param  int  $siteId
      * @param  int  $certificateId
      * @param  bool  $wait
-     * @return void
+     * @return \Laravel\Forge\Resources\Certificate
      */
     public function activateCertificate($serverId, $siteId, $certificateId, $wait = true)
     {
@@ -129,6 +131,8 @@ trait ManagesCertificates
                 return $certificate->activationStatus == 'activated';
             });
         }
+
+        return $this->certificate($serverId, $siteId, $certificateId);
     }
 
     /**

--- a/src/Actions/ManagesServers.php
+++ b/src/Actions/ManagesServers.php
@@ -105,11 +105,11 @@ trait ManagesServers
      * Reconnect the server to Forge with a new key.
      *
      * @param  string  $serverId
-     * @return void
+     * @return string
      */
     public function reconnectToServer($serverId)
     {
-        $this->post("servers/$serverId/reconnect")['public_key'];
+        return $this->post("servers/$serverId/reconnect")['public_key'];
     }
 
     /**

--- a/src/Actions/ManagesSiteCommands.php
+++ b/src/Actions/ManagesSiteCommands.php
@@ -45,10 +45,6 @@ trait ManagesSiteCommands
     {
         $command = $this->get("servers/$serverId/sites/$siteId/commands/$commandId");
 
-        return $this->transformCollection(
-            [$command['command']],
-            SiteCommand::class,
-            ['output' => $command['output']]
-        );
+        return new SiteCommand($command['command'] + ['output' => $command['output']], $this);
     }
 }

--- a/src/Actions/ManagesSites.php
+++ b/src/Actions/ManagesSites.php
@@ -348,7 +348,7 @@ trait ManagesSites
      */
     public function deploymentHistory($serverId, $siteId)
     {
-        return $this->get("/api/v1/servers/$serverId/sites/$siteId/deployment-history");
+        return $this->get("servers/$serverId/sites/$siteId/deployment-history");
     }
 
     /**
@@ -361,7 +361,7 @@ trait ManagesSites
      */
     public function deploymentHistoryDeployment($serverId, $siteId, $deploymentId)
     {
-        return $this->get("/api/v1/servers/$serverId/sites/$siteId/deployment-history/$deploymentId");
+        return $this->get("servers/$serverId/sites/$siteId/deployment-history/$deploymentId");
     }
 
     /**
@@ -374,7 +374,7 @@ trait ManagesSites
      */
     public function deploymentHistoryOutput($serverId, $siteId, $deploymentId)
     {
-        return $this->get("/api/v1/servers/$serverId/sites/$siteId/deployment-history/$deploymentId/output");
+        return $this->get("servers/$serverId/sites/$siteId/deployment-history/$deploymentId/output");
     }
 
     /**

--- a/src/Actions/ManagesWorkers.php
+++ b/src/Actions/ManagesWorkers.php
@@ -81,7 +81,7 @@ trait ManagesWorkers
      * @param  int  $siteId
      * @param  int  $workerId
      * @param  bool  $wait
-     * @return void
+     * @return \Laravel\Forge\Resources\Worker
      */
     public function restartWorker($serverId, $siteId, $workerId, $wait = true)
     {
@@ -94,5 +94,7 @@ trait ManagesWorkers
                 return $key->status == 'installed';
             });
         }
+
+        return $this->worker($serverId, $siteId, $workerId);
     }
 }

--- a/src/MakesHttpRequests.php
+++ b/src/MakesHttpRequests.php
@@ -99,7 +99,7 @@ trait MakesHttpRequests
      */
     protected function handleRequestError(ResponseInterface $response)
     {
-        if ($response->getStatusCode() == 422) {
+        if ($response->getStatusCode() === 422) {
             throw new ValidationException(json_decode((string) $response->getBody(), true));
         }
 
@@ -107,11 +107,11 @@ trait MakesHttpRequests
             throw new ForbiddenException((string) $response->getBody());
         }
 
-        if ($response->getStatusCode() == 404) {
+        if ($response->getStatusCode() === 404) {
             throw new NotFoundException;
         }
 
-        if ($response->getStatusCode() == 400) {
+        if ($response->getStatusCode() === 400) {
             throw new FailedActionException((string) $response->getBody());
         }
 


### PR DESCRIPTION
## Summary
- Add missing `return` in `reconnectToServer()` so the public key is actually returned (fixes #1)
- Add missing `return` in `installCertificate()` when `wait=true` (fixes #2)
- Add missing `return` in `activateCertificate()` when `wait=true` (fixes #3)
- Add missing `return` in `restartWorker()` when `wait=true` (fixes #4)
- Remove `/api/v1/` prefix from deployment history methods for consistency with all other SDK methods (fixes #5)
- Use strict `===` consistently for all HTTP status code comparisons in error handling (fixes #6)
- Fix `getSiteCommand()` to return a single `SiteCommand` instead of a collection (fixes #7)

## Test plan
- [ ] Verify `reconnectToServer()` returns the public key string
- [ ] Verify `installCertificate()` and `activateCertificate()` return Certificate instances after waiting
- [ ] Verify `restartWorker()` returns Worker instance after waiting
- [ ] Verify deployment history methods work without `/api/v1/` prefix (base URI already includes it)
- [ ] Verify error handling still throws correct exceptions for each status code
- [ ] Verify `getSiteCommand()` returns a single SiteCommand instance, not an array

🤖 Generated with [Claude Code](https://claude.com/claude-code)