### PR TITLE
Fix incorrect docstrings across resource and action files

### DIFF
--- a/src/Actions/ManagesSiteCommands.php
+++ b/src/Actions/ManagesSiteCommands.php
@@ -23,7 +23,7 @@ trait ManagesSiteCommands
      *
      * @param  int  $serverId
      * @param  int  $siteId
-     * @return \Laravel\Forge\Resources\SiteCommand
+     * @return \Laravel\Forge\Resources\SiteCommand[]
      */
     public function listCommandHistory($serverId, $siteId)
     {

--- a/src/Resources/BackupConfiguration.php
+++ b/src/Resources/BackupConfiguration.php
@@ -65,7 +65,7 @@ class BackupConfiguration extends Resource
     public $databases;
 
     /**
-     * The databases for this backup.
+     * The backups for this configuration.
      *
      * @var \Laravel\Forge\Resources\Backup[]
      */

--- a/src/Resources/SecurityRule.php
+++ b/src/Resources/SecurityRule.php
@@ -40,7 +40,7 @@ class SecurityRule extends Resource
     public $path;
 
     /**
-     * The credentials of the redirect rule.
+     * The credentials of the security rule.
      *
      * @var string
      */
@@ -54,7 +54,7 @@ class SecurityRule extends Resource
     public $createdAt;
 
     /**
-     * Delete the given redirect rule.
+     * Delete the given security rule.
      *
      * @return void
      */

--- a/src/Resources/Site.php
+++ b/src/Resources/Site.php
@@ -201,7 +201,7 @@ class Site extends Resource
     public $phpVersion;
 
     /**
-     * The aliases of the site.
+     * The tags of the site.
      *
      * @var array
      */

--- a/src/Resources/SiteCommand.php
+++ b/src/Resources/SiteCommand.php
@@ -61,7 +61,7 @@ class SiteCommand extends Resource
     public $createdAt;
 
     /**
-     * The The updated_at time for the command.
+     * The updated_at time for the command.
      *
      * @var string
      */


### PR DESCRIPTION
## Summary
- Fix "redirect rule" -> "security rule" in `SecurityRule` class docstrings (fixes #8)
- Remove duplicate "The The" in `SiteCommand::$updatedAt` docstring (fixes #9)
- Fix "aliases" -> "tags" in `Site::$tags` property docstring (fixes #10)
- Fix "databases" -> "backups" in `BackupConfiguration::$backups` property docstring (fixes #11)
- Fix return type on `listCommandHistory()` from `SiteCommand` to `SiteCommand[]` (fixes #12)

## Test plan
- [ ] Review docstring changes for accuracy
- [ ] Confirm no functional code changes were made

🤖 Generated with [Claude Code](https://claude.com/claude-code)